### PR TITLE
Relying on autoresizing mask + intrinsic content size instead of the constraint

### DIFF
--- a/Sources/SwiftUIPDF/PDFPageView.swift
+++ b/Sources/SwiftUIPDF/PDFPageView.swift
@@ -26,9 +26,8 @@ public final class AutoresizablePDFPageView: UIView {
     
     private var pageSize: CGSize? {
         didSet {
-            aspectRatioConsrtaint = pageSize.map {
-                widthAnchor.constraint(equalTo: heightAnchor, multiplier: $0.width / $0.height)
-            }
+            guard pageSize != oldValue else { return }
+            invalidateIntrinsicContentSize()
         }
     }
     

--- a/Sources/SwiftUIPDF/PDFPageView.swift
+++ b/Sources/SwiftUIPDF/PDFPageView.swift
@@ -19,11 +19,6 @@ import SwiftUI
 @available(iOS 11.0, *)
 public final class AutoresizablePDFPageView: UIView {
     
-    private var aspectRatioConsrtaint: NSLayoutConstraint? {
-        willSet { aspectRatioConsrtaint?.isActive = false }
-        didSet { aspectRatioConsrtaint?.isActive = true }
-    }
-    
     private var pageSize: CGSize? {
         didSet {
             guard pageSize != oldValue else { return }


### PR DESCRIPTION
Solving constraints errors in the console by removing constraint. The view can successfully resize using the autoresizing mask along with intrinsic content size value